### PR TITLE
feat: strict_format_and_match reward — whole-output format compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Core algorithm is as in the paper: Stage I anchors attempt 1 to the reference po
 
 - **Reasoning-tag format from [DeepSeek-R1](https://arxiv.org/abs/2501.12948)** (the GRPO paper): model reasons inside `<think>...</think>` and gives the final answer inside `<answer>...</answer>`. The compound reward below scores this format directly.
 - **K3 KL estimator** (Schulman): `K3 = exp(log π_ref − log π) − (log π_ref − log π) − 1`. Unbiased forward KL from per-token log-probs only — no `[B, T, V]` log-softmax tensor, which is what makes Stage II's two-graph backward fit in memory.
-- **Compound reward** (`format_and_match`): 0.25 for a `<think>...</think>` pair, 0.25 for one `<answer>...</answer>` pair, 0.5 for extracted-answer match. Gives the α-bonus more signal than pure binary and explicitly anchors format.
+- **Compound reward** (`format_and_match`): 0.25 for a `<think>...</think>` pair, 0.25 for one `<answer>...</answer>` pair, 0.5 for extracted-answer match. Gives the α-bonus more signal than pure binary and explicitly anchors format. A stricter `strict_format_and_match` variant (0.5 format / 0.5 match) requires the *whole* output to be exactly the two blocks — no prose between `</think>` and `<answer>`, nothing after `</answer>`. Select either via `reward.fn` in the YAML.
 - **LoRA-only**: reference policy = same model with `model.disable_adapter()`. No second model in VRAM.
 
 ## Layout

--- a/README.md
+++ b/README.md
@@ -35,10 +35,22 @@ python train.py --config configs/gsm8k.yaml --smoke 8
 
 Logs go to W&B (`wandb_project` in the config). LoRA adapters save to `outputs/{run_name}/stage{1,2}/`.
 
+## Selecting the reward
+
+The reward function and answer extractor are chosen by name in the YAML — `train.py` looks them up from the `reward_function.py` registries:
+
+```yaml
+reward:
+  fn: strict_format_and_match    # or: format_and_match, exact_match
+  answer_extractor: gsm8k_hash   # or: math_final_answer, identity
+```
+
+Shipped reward functions: `format_and_match` (loose tag check), `strict_format_and_match` (whole-output must be exactly the two blocks), `exact_match` (extracted-answer equality only).
+
 ## Adapt to a new task
 
 1. Push your dataset to the HF Hub with `train` and `test` splits. For datasets needing a sub-config (e.g. `openai/gsm8k` has `main`/`socratic`), set `dataset.config_name`.
 2. Add an answer extractor in `reward_function.py` if the shipped ones don't fit (`gsm8k_hash`, `math_final_answer`, `identity`).
-3. Add a reward function if `format_and_match` or `exact_match` don't fit.
+3. Add a reward function if none of the shipped ones fit.
 4. Copy `configs/gsm8k.yaml`, edit `model.*` / `dataset.*` / `prompts.*` / `reward.*`.
 5. Smoke first (`--smoke 8`), then full.

--- a/reward_function.py
+++ b/reward_function.py
@@ -88,12 +88,17 @@ def _has_one_answer_tag(text: str) -> bool:
 def format_and_match(
     predictions: list[str], targets: list[str], extractor: AnswerExtractor
 ) -> list[float]:
-    """Compound reward: tag format compliance + answer correctness.
+    """Compound reward: loose tag format compliance + answer correctness.
 
     Per prediction:
       - 0.25 for a balanced ``<think>...</think>`` pair (reasoning closed).
       - 0.25 for exactly one balanced ``<answer>...</answer>`` pair.
       - 0.50 for the extracted answer matching the target after normalization.
+
+    "Loose": the tags only need to appear *somewhere* — arbitrary prose is
+    tolerated before, between, and after the two blocks. For a version that
+    requires the whole output to be exactly the two blocks, see
+    ``strict_format_and_match``.
 
     Returns floats in [0.0, 1.0]. Format checks apply to predictions only;
     targets may not follow the same format conventions (e.g. dataset
@@ -106,6 +111,63 @@ def format_and_match(
             r += 0.25
         if _has_one_answer_tag(pred):
             r += 0.25
+        if _normalize(extractor(pred)) == _normalize(extractor(target)):
+            r += 0.5
+        rewards.append(r)
+    return rewards
+
+
+_STRICT_FORMAT = re.compile(
+    r"^\s*<think>(.*?)</think>\s*<answer>(.*?)</answer>\s*$",
+    flags=re.DOTALL,
+)
+
+
+def _has_strict_format(text: str) -> bool:
+    """The ENTIRE output is exactly ``<think>...</think><answer>...</answer>``.
+
+    Only whitespace is permitted before ``<think>``, between ``</think>`` and
+    ``<answer>``, and after ``</answer>`` — no prose anywhere outside the two
+    blocks, and exactly one of each tag.
+
+    The ``.count()`` guards are not redundant with the regex: ``.*?`` with
+    ``DOTALL`` backtracks across a second ``<think>`` block to reach a later
+    ``</think>``, so a pure regex would accept duplicated blocks. Counting
+    tags first rejects those; the regex then enforces ordering + no-prose.
+    """
+    if text.count("<think>") != 1 or text.count("</think>") != 1:
+        return False
+    if text.count("<answer>") != 1 or text.count("</answer>") != 1:
+        return False
+    return _STRICT_FORMAT.match(text) is not None
+
+
+@register_reward("strict_format_and_match")
+def strict_format_and_match(
+    predictions: list[str], targets: list[str], extractor: AnswerExtractor
+) -> list[float]:
+    """Stricter compound reward: whole-output format compliance + answer correctness.
+
+    Per prediction:
+      - 0.50 for STRICT format: the entire output is exactly one
+        ``<think>...</think>`` block immediately followed by exactly one
+        ``<answer>...</answer>`` block, with only whitespace before, between,
+        and after. All-or-nothing.
+      - 0.50 for the extracted answer matching the target after normalization.
+
+    Contrast with ``format_and_match``, which splits the format reward into
+    two loose 0.25 checks (tags exist *somewhere*) and tolerates arbitrary
+    prose around and between the blocks. Select this via ``reward.fn`` in the
+    YAML when you want the model to learn the exact output shape — no prose
+    leaking between ``</think>`` and ``<answer>``, nothing after ``</answer>``.
+
+    Returns floats in [0.0, 1.0].
+    """
+    rewards: list[float] = []
+    for pred, target in zip(predictions, targets):
+        r = 0.0
+        if _has_strict_format(pred):
+            r += 0.5
         if _normalize(extractor(pred)) == _normalize(extractor(target)):
             r += 0.5
         rewards.append(r)


### PR DESCRIPTION
## Summary

Adds a second, stricter compound reward, selectable via `reward.fn` in the YAML. No `train.py` change needed — the `@register_reward` registry handles config-selection automatically.

## The two rewards

| | `format_and_match` (existing) | `strict_format_and_match` (new) |
|---|---|---|
| `<think>` / `<answer>` tags | must appear *somewhere* | must be the *entire* output |
| Prose between `</think>` and `<answer>` | allowed | **rejected** |
| Text after `</answer>` | allowed | **rejected** |
| Text before `<think>` | allowed | **rejected** |
| Duplicate blocks | partially tolerated | **rejected** |
| Reward split | 0.25 think / 0.25 answer / 0.5 match | 0.5 format (all-or-nothing) / 0.5 match |

Whitespace (e.g. a newline between `</think>` and `<answer>`) is **not** treated as prose — models naturally emit it, and requiring zero whitespace would fail well-behaved outputs.

## Implementation note

`_has_strict_format` does `.count()` guards on each tag *in addition to* the anchored regex. The regex's backtracking `.*?` under `DOTALL` would otherwise accept duplicated blocks — `<think>a</think><think>b</think><answer>c</answer>` slips past a pure regex because `.*?` expands across the second `<think>` to reach a later `</think>`. Counting `== 1` each rejects those first.

## Verification

Tested locally — all pass:
- 12 format edge cases: tight, newline-separated, whitespace-padded, prose-between, trailing-text, leading-text, doubled think block, doubled answer block, missing think, missing answer, no tags, multiline think body.
- Reward composition: strict-format (0.5) and answer-correctness (0.5) compose independently → `[1.0, 0.5, 0.5, 0.0]` for [strict+correct, loose+correct, strict+wrong, neither].

## Usage

```yaml
reward:
  fn: strict_format_and_match    # was: format_and_match
  answer_extractor: gsm8k_hash
```