### PR TITLE
feat: fast toy task — single-digit composite arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ pip install -r requirements.txt
 # full run
 python train.py --config configs/gsm8k.yaml
 
+# fast toy task (~1h two-stage run) — good for debugging the loop end-to-end
+python train.py --config configs/arithmetic.yaml
+
 # 1-minute end-to-end smoke (N examples, capped eval)
 python train.py --config configs/gsm8k.yaml --smoke 8
 
@@ -41,6 +44,8 @@ python train.py --config configs/gsm8k.yaml \
 ```
 
 Logs go to W&B (`wandb_project` in the config). End-of-stage adapters save to `outputs/{run_name}/stage{1,2}/`. Set `train.checkpoint_every: N` in the YAML to also save mid-stage to `outputs/{run_name}/stage{1,2}/step_N/` every N optimizer steps — useful for resuming or for picking the best checkpoint by reward curve.
+
+`configs/arithmetic.yaml` uses [`torchtrade/arithmetic-hard-qwen3-0.6b`](https://huggingface.co/datasets/torchtrade/arithmetic-hard-qwen3-0.6b) — 200 train / 50 eval 5-digit subtractions that Qwen3-0.6B fails greedy-decoded (built by `build_hard_arithmetic.py`; see the dataset card for source + method). It's a debug/shake-out task, not a benchmark: difficulty is defined relative to that one model, so a full two-stage run finishes in ~1h and stresses every part of the loop.
 
 ## Adapt to a new task
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Core algorithm is as in the paper: Stage I anchors attempt 1 to the reference po
 train.py                 # task-agnostic entry point
 reward_function.py       # @register_reward / @register_extractor + shipped fns
 configs/gsm8k.yaml       # primary target
-configs/arithmetic.yaml  # fast toy task (single-digit composite arithmetic) — full run in a few hours
+configs/arithmetic.yaml  # fast toy task — 5-digit subtraction Qwen3-0.6B can't solve; full run < 1h
 configs/math.yaml        # math baseline
+build_hard_arithmetic.py # builds the toy-task dataset (greedy-decode, keep the failures)
 profile_run.py           # optional length/extraction diagnostic
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ Core algorithm is as in the paper: Stage I anchors attempt 1 to the reference po
 ## Layout
 
 ```
-train.py              # task-agnostic entry point
-reward_function.py    # @register_reward / @register_extractor + shipped fns
-configs/gsm8k.yaml    # primary target
-configs/math.yaml     # math baseline
-profile_run.py        # optional length/extraction diagnostic
+train.py                 # task-agnostic entry point
+reward_function.py       # @register_reward / @register_extractor + shipped fns
+configs/gsm8k.yaml       # primary target
+configs/arithmetic.yaml  # fast toy task (single-digit composite arithmetic) — full run in a few hours
+configs/math.yaml        # math baseline
+profile_run.py           # optional length/extraction diagnostic
 ```
 
 `train.py` never references a specific task — model, dataset, prompts, reward, and extractor are all YAML.

--- a/build_hard_arithmetic.py
+++ b/build_hard_arithmetic.py
@@ -1,0 +1,95 @@
+"""Build a small "hard arithmetic" dataset — 5-digit subtraction Qwen3-0.6B can't solve.
+
+Greedy-decodes a pool of 5-digit subtraction problems (the hardest
+EleutherAI/arithmetic subset for this model, ~52% greedy-fail), keeps the
+ones the model gets wrong, cleans the question text, and saves a HF
+DatasetDict with train/test splits via save_to_disk.
+
+Run inside the unsloth-dgx-spark container on Spark (GPU). Push to the Hub
+happens separately from a machine with an HF token.
+
+Usage:
+    python build_hard_arithmetic.py
+"""
+import re
+import numpy as np
+from datasets import load_dataset, Dataset, DatasetDict
+from unsloth import FastLanguageModel
+import reward_function as rf
+
+POOL_OFFSET = 18000            # rows 18000-19999 of the parquet export = arithmetic_5ds
+POOL_SIZE = 700                # ~52% greedy-fail -> ~360 hard, plenty for 250
+GEN_BATCH = 128                # inference-only, greedy
+MAX_NEW = 768
+N_TRAIN, N_EVAL = 200, 50
+OUT = "data/arithmetic_hard"
+MODEL = "Qwen/Qwen3-0.6B"
+SYSTEM = (
+    "You are an arithmetic solver. Output EXACTLY this format and nothing else:\n"
+    "<think>\na brief calculation — just the arithmetic steps, no commentary\n</think>\n"
+    "<answer>the final number</answer>\n"
+    "Keep the reasoning short. Put only the bare number between the answer tags."
+)
+
+_QPREFIX = re.compile(r"^\s*Question:\s*", re.IGNORECASE)
+_ASUFFIX = re.compile(r"\s*Answer:\s*$", re.IGNORECASE)
+
+
+def clean_question(ctx: str) -> str:
+    """EleutherAI ships 'Question: What is X?\\nAnswer:' — strip the framing so
+    build() in train.py doesn't double the 'Question:' prefix."""
+    return _ASUFFIX.sub("", _QPREFIX.sub("", ctx)).strip()
+
+
+def main() -> None:
+    model, tok = FastLanguageModel.from_pretrained(
+        model_name=MODEL, max_seq_length=2048, dtype=None, load_in_4bit=False)
+    FastLanguageModel.for_inference(model)
+    gsm = rf.ANSWER_EXTRACTORS["gsm8k_hash"]
+
+    ds = load_dataset("EleutherAI/arithmetic", "default", revision="refs/convert/parquet",
+                      split=f"validation[{POOL_OFFSET}:{POOL_OFFSET + POOL_SIZE}]")
+    rows = [{"question": clean_question(ex["context"]), "answer": ex["completion"].strip()}
+            for ex in ds]
+    print(f"pooled {len(rows)} candidate 5-digit-subtraction questions")
+
+    # Greedy-decode in big batches; "hard" = greedy gets it wrong (or emits no number)
+    hard = []
+    for i in range(0, len(rows), GEN_BATCH):
+        batch = rows[i:i + GEN_BATCH]
+        prompts = [
+            tok.apply_chat_template(
+                [{"role": "system", "content": SYSTEM},
+                 {"role": "user", "content": "Question:\n" + r["question"]}],
+                tokenize=False, add_generation_prompt=True)
+            for r in batch
+        ]
+        x = tok(prompts, padding="longest", padding_side="left", return_tensors="pt").to(model.device)
+        out = model.generate(x["input_ids"], attention_mask=x["attention_mask"],
+                             max_new_tokens=MAX_NEW, do_sample=False)
+        gen = tok.batch_decode(out[:, x["input_ids"].shape[1]:], skip_special_tokens=True)
+        for r, g in zip(batch, gen):
+            if gsm(g) == "" or gsm(g) != gsm(r["answer"]):
+                hard.append(r)
+        print(f"  scored {min(i + GEN_BATCH, len(rows))}/{len(rows)}  hard so far: {len(hard)}")
+
+    fail = 100 * len(hard) / len(rows)
+    print(f"\n{len(hard)}/{len(rows)} greedy-wrong = {fail:.0f}% fail rate")
+    if len(hard) < N_TRAIN + N_EVAL:
+        raise SystemExit(f"only {len(hard)} hard questions, need {N_TRAIN + N_EVAL}")
+
+    rng = np.random.default_rng(3407)
+    rng.shuffle(hard)
+    sel = hard[: N_TRAIN + N_EVAL]
+    dd = DatasetDict({
+        "train": Dataset.from_list(sel[:N_TRAIN]),
+        "test": Dataset.from_list(sel[N_TRAIN:]),
+    })
+    print(f"\nfinal: train={len(dd['train'])}  test={len(dd['test'])}")
+    print(f"  sample: {dd['train'][0]}")
+    dd.save_to_disk(OUT)
+    print(f"saved to {OUT}/  — scp to a machine with an HF token, then push_to_hub")
+
+
+if __name__ == "__main__":
+    main()

--- a/configs/arithmetic.yaml
+++ b/configs/arithmetic.yaml
@@ -1,16 +1,23 @@
 run_name: score-arithmetic
 wandb_project: SCoRe-Arithmetic
 
-# Toy task: single-digit composite arithmetic, e.g. "(9 + 8) * 2 = 34".
-# Two operations (needs order-of-operations + 2 arithmetic steps) but tiny
-# operands, so reasoning is ~20 tokens and the answer is ~1-3 chars. ~10x
-# shorter generation than gsm8k -> a full two-stage run finishes in a few
-# hours instead of days. Use it to validate the training loop / new features
-# before committing Spark wallclock to a real task.
+# Toy task: 5-digit addition, e.g. "65360 + 16204 = 81564". Subset picked by
+# probing Qwen3-0.6B across all EleutherAI/arithmetic subsets at this exact
+# config — 5da lands ~68% attempt-1 accuracy, the SCoRe Goldilocks zone
+# (1-4 digit arithmetic measured 74-92% = too easy; 5-digit subtraction was
+# ~48% but with 42% truncation = poisoned signal). 1800 train / 200 eval at
+# batch 32 = ~56 steps/stage (vs gsm8k's 269), and generation averages ~410
+# tokens (vs gsm8k's ~840) — a full two-stage run is a few hours, not days.
+# Use it to shake out the training loop / new features before spending
+# Spark wallclock on a real task.
+#
+# At this config the probe measured ~88% format compliance and ~12%
+# truncation pre-training — both should improve under the format reward +
+# length tracking, and watching them do so validates those features.
 
 model:
   name: Qwen/Qwen3-0.6B
-  max_seq_length: 1024              # tiny task: prompt (~150) + 2x gen (256) + headroom
+  max_seq_length: 2048              # prompt (~150) + 2x gen (768) + headroom
   load_in_4bit: false
   chat_template: ""                 # empty = tokenizer's built-in
   fast_inference: false
@@ -33,25 +40,27 @@ dataset:
   config_name: default              # the parquet export collapses all 10 subsets into one config
   revision: refs/convert/parquet    # EleutherAI/arithmetic ships a legacy dataset script; the
                                     # auto-generated parquet export is the loadable form
-  split: validation[:2000]          # rows 0-1999 of the export are the arithmetic_1dc subset
-                                    # (single-digit composite); single split -> partitioned below
-  input_field: context              # e.g. "Question: What is (9 + 8) * 2?\nAnswer:"
-  target_field: completion          # bare number, e.g. " 34" — gsm8k_hash strips + extracts
+  split: validation[16000:18000]    # rows 16000-17999 of the export are the arithmetic_5da subset
+                                    # (5-digit addition); single split -> partitioned below
+  input_field: context              # e.g. "Question: What is 65360 plus 16204?\nAnswer:"
+  target_field: completion          # bare number, e.g. " 81564" — gsm8k_hash strips + extracts
   test_split_size: 200              # 200 held out for eval, remaining 1800 -> train
 
 prompts:
   system: |
-    You are a careful arithmetic tutor. Solve the expression step by step.
-    Wrap all your reasoning in <think>...</think> tags — show each operation.
-    After </think>, wrap the final answer in <answer>...</answer> tags.
-    Put only the bare number between the tags — no words, just the number.
+    You are an arithmetic solver. Output EXACTLY this format and nothing else:
+    <think>
+    a brief calculation — just the arithmetic steps, no commentary
+    </think>
+    <answer>the final number</answer>
+    Keep the reasoning short. Put only the bare number between the answer tags.
 
   self_correction: |
-    There might be an error in the solution above. Review the prior reasoning
-    and the answer (and the format). Identify any mistake and rewrite the solution.
+    There might be an error in the solution above. Re-check the arithmetic and
+    the format. Identify any mistake and rewrite the solution.
 
     Use the same format: <think>...</think> for your corrected reasoning, then
-    <answer>...</answer> for the final answer.
+    <answer>...</answer> for the final number.
 
 reward:
   fn: format_and_match              # 0.25 <think> + 0.25 <answer> + 0.5 correct number.
@@ -66,10 +75,10 @@ train:
   beta1: 0.01
   beta2: 0.1
   alpha: 10.0
-  max_new_tokens_attempt1: 256      # reasoning for (a op b) op c is ~20 tokens; 256 is generous
-  max_new_tokens_attempt2: 256
+  max_new_tokens_attempt1: 768      # Qwen3-0.6B thinking mode rambles ~400-500 tokens even on
+  max_new_tokens_attempt2: 768      # simple arithmetic; 768 keeps most rollouts from truncating
   max_prompt_length_attempt1: 384   # system prompt + short expression
-  max_prompt_length_attempt2: 768   # attempt1 prompt + attempt1 output (up to 256) + self-correction
+  max_prompt_length_attempt2: 1024  # attempt1 prompt + attempt1 output (up to 768) + self-correction
   generation_temperature: 0.6       # Qwen3 thinking mode: >0 required
   seed: 3407
   length_norm: sequence             # "constant" for the Dr.GRPO length-bias fix (see gsm8k.yaml)

--- a/configs/arithmetic.yaml
+++ b/configs/arithmetic.yaml
@@ -1,0 +1,80 @@
+run_name: score-arithmetic
+wandb_project: SCoRe-Arithmetic
+
+# Toy task: single-digit composite arithmetic, e.g. "(9 + 8) * 2 = 34".
+# Two operations (needs order-of-operations + 2 arithmetic steps) but tiny
+# operands, so reasoning is ~20 tokens and the answer is ~1-3 chars. ~10x
+# shorter generation than gsm8k -> a full two-stage run finishes in a few
+# hours instead of days. Use it to validate the training loop / new features
+# before committing Spark wallclock to a real task.
+
+model:
+  name: Qwen/Qwen3-0.6B
+  max_seq_length: 1024              # tiny task: prompt (~150) + 2x gen (256) + headroom
+  load_in_4bit: false
+  chat_template: ""                 # empty = tokenizer's built-in
+  fast_inference: false
+  fast_inference_gpu_mem: 0.5
+  lora:
+    r: 16
+    alpha: 16
+    dropout: 0.0
+    target_modules:
+      - q_proj
+      - k_proj
+      - v_proj
+      - o_proj
+      - gate_proj
+      - up_proj
+      - down_proj
+
+dataset:
+  name: EleutherAI/arithmetic
+  config_name: default              # the parquet export collapses all 10 subsets into one config
+  revision: refs/convert/parquet    # EleutherAI/arithmetic ships a legacy dataset script; the
+                                    # auto-generated parquet export is the loadable form
+  split: validation[:2000]          # rows 0-1999 of the export are the arithmetic_1dc subset
+                                    # (single-digit composite); single split -> partitioned below
+  input_field: context              # e.g. "Question: What is (9 + 8) * 2?\nAnswer:"
+  target_field: completion          # bare number, e.g. " 34" — gsm8k_hash strips + extracts
+  test_split_size: 200              # 200 held out for eval, remaining 1800 -> train
+
+prompts:
+  system: |
+    You are a careful arithmetic tutor. Solve the expression step by step.
+    Wrap all your reasoning in <think>...</think> tags — show each operation.
+    After </think>, wrap the final answer in <answer>...</answer> tags.
+    Put only the bare number between the tags — no words, just the number.
+
+  self_correction: |
+    There might be an error in the solution above. Review the prior reasoning
+    and the answer (and the format). Identify any mistake and rewrite the solution.
+
+    Use the same format: <think>...</think> for your corrected reasoning, then
+    <answer>...</answer> for the final answer.
+
+reward:
+  fn: format_and_match              # 0.25 <think> + 0.25 <answer> + 0.5 correct number.
+  answer_extractor: gsm8k_hash      # pulls the number from <answer>N</answer> or bare target
+
+train:
+  stage1_batch_size: 32
+  stage2_batch_size: 32
+  learning_rate: 2.0e-5
+  stage1_epochs: 1
+  stage2_epochs: 1
+  beta1: 0.01
+  beta2: 0.1
+  alpha: 10.0
+  max_new_tokens_attempt1: 256      # reasoning for (a op b) op c is ~20 tokens; 256 is generous
+  max_new_tokens_attempt2: 256
+  max_prompt_length_attempt1: 384   # system prompt + short expression
+  max_prompt_length_attempt2: 768   # attempt1 prompt + attempt1 output (up to 256) + self-correction
+  generation_temperature: 0.6       # Qwen3 thinking mode: >0 required
+  seed: 3407
+  length_norm: sequence             # "constant" for the Dr.GRPO length-bias fix (see gsm8k.yaml)
+
+eval:
+  batch_size: 50
+  max_examples: 200                 # matches test_split_size
+  generation_temperature: 0.0

--- a/configs/arithmetic.yaml
+++ b/configs/arithmetic.yaml
@@ -1,19 +1,17 @@
 run_name: score-arithmetic
 wandb_project: SCoRe-Arithmetic
 
-# Toy task: 5-digit addition, e.g. "65360 + 16204 = 81564". Subset picked by
-# probing Qwen3-0.6B across all EleutherAI/arithmetic subsets at this exact
-# config — 5da lands ~68% attempt-1 accuracy, the SCoRe Goldilocks zone
-# (1-4 digit arithmetic measured 74-92% = too easy; 5-digit subtraction was
-# ~48% but with 42% truncation = poisoned signal). 1800 train / 200 eval at
-# batch 32 = ~56 steps/stage (vs gsm8k's 269), and generation averages ~410
-# tokens (vs gsm8k's ~840) — a full two-stage run is a few hours, not days.
-# Use it to shake out the training loop / new features before spending
-# Spark wallclock on a real task.
+# Fast toy task: 5-digit subtraction questions that Qwen3-0.6B CANNOT solve.
+# Built by greedy-decoding 700 EleutherAI/arithmetic 5ds problems with this
+# model and keeping the ~48% it gets wrong (see build_hard_arithmetic.py),
+# then taking 200 train / 50 eval. Because every example is a known failure,
+# attempt-1 accuracy starts near 0% — maximal room for self-correction, and
+# the format reward (0.25+0.25) carries the early gradient signal.
 #
-# At this config the probe measured ~88% format compliance and ~12%
-# truncation pre-training — both should improve under the format reward +
-# length tracking, and watching them do so validates those features.
+# Tiny + fast: 200 train at batch 16 = ~13 steps/stage (vs gsm8k's 269),
+# eval is a single batch of 50. A full two-stage run is well under an hour
+# of training. Use it to shake out the loop / new features before spending
+# Spark wallclock on a real task.
 
 model:
   name: Qwen/Qwen3-0.6B
@@ -36,15 +34,10 @@ model:
       - down_proj
 
 dataset:
-  name: EleutherAI/arithmetic
-  config_name: default              # the parquet export collapses all 10 subsets into one config
-  revision: refs/convert/parquet    # EleutherAI/arithmetic ships a legacy dataset script; the
-                                    # auto-generated parquet export is the loadable form
-  split: validation[16000:18000]    # rows 16000-17999 of the export are the arithmetic_5da subset
-                                    # (5-digit addition); single split -> partitioned below
-  input_field: context              # e.g. "Question: What is 65360 plus 16204?\nAnswer:"
-  target_field: completion          # bare number, e.g. " 81564" — gsm8k_hash strips + extracts
-  test_split_size: 200              # 200 held out for eval, remaining 1800 -> train
+  name: torchtrade/arithmetic-hard-qwen3-0.6b   # curated: 5-digit subtractions Qwen3-0.6B fails
+  input_field: question             # clean text, e.g. "What is 70641 minus 71101?"
+  target_field: answer              # bare number, e.g. "-460" — gsm8k_hash extracts it
+  test_split_size: 50               # dataset ships train(200)/test(50); all 50 test -> held-out eval
 
 prompts:
   system: |
@@ -67,8 +60,8 @@ reward:
   answer_extractor: gsm8k_hash      # pulls the number from <answer>N</answer> or bare target
 
 train:
-  stage1_batch_size: 32
-  stage2_batch_size: 32
+  stage1_batch_size: 16             # 200 train -> ~13 steps/stage. batch 16 not 32: same total
+  stage2_batch_size: 16             # generation wallclock per epoch but 2x the optimizer steps.
   learning_rate: 2.0e-5
   stage1_epochs: 1
   stage2_epochs: 1
@@ -82,10 +75,10 @@ train:
   generation_temperature: 0.6       # Qwen3 thinking mode: >0 required
   seed: 3407
   length_norm: sequence             # "constant" for the Dr.GRPO length-bias fix (see gsm8k.yaml)
-  checkpoint_every: 15              # ~56 steps/stage -> saves at 15/30/45 + end-of-stage = 4/stage.
+  checkpoint_every: 4               # ~13 steps/stage -> saves at 4/8/12 + end-of-stage = 4/stage.
                                     # exercises the mid-stage checkpoint feature on this toy run.
 
 eval:
   batch_size: 50
-  max_examples: 200                 # matches test_split_size
+  max_examples: 50                  # one batch of 50 — the dataset's full test split
   generation_temperature: 0.0

--- a/configs/arithmetic.yaml
+++ b/configs/arithmetic.yaml
@@ -82,6 +82,8 @@ train:
   generation_temperature: 0.6       # Qwen3 thinking mode: >0 required
   seed: 3407
   length_norm: sequence             # "constant" for the Dr.GRPO length-bias fix (see gsm8k.yaml)
+  checkpoint_every: 15              # ~56 steps/stage -> saves at 15/30/45 + end-of-stage = 4/stage.
+                                    # exercises the mid-stage checkpoint feature on this toy run.
 
 eval:
   batch_size: 50

--- a/train.py
+++ b/train.py
@@ -77,6 +77,11 @@ class DatasetConfig:
     target_field: str
     test_split_size: int
     config_name: str | None = None    # for HF datasets that require a sub-config (e.g. openai/gsm8k "main")
+    split: str | None = None          # if set, load just this one split spec (slicing allowed, e.g.
+                                      # "validation[:2000]") and partition it into train + held-out
+                                      # eval. None = expect separate "train" and "test" splits.
+    revision: str | None = None       # HF dataset revision — e.g. "refs/convert/parquet" to use the
+                                      # auto-generated parquet export of a legacy script dataset.
 
 
 @dataclass
@@ -231,27 +236,44 @@ def load_and_prepare_data(
 ) -> tuple[Any, Any]:
     """Load dataset and pre-build chat-templated prompts.
 
-    The test split is partitioned: the first `test_split_size` examples become the
-    held-out eval set; the remainder is concatenated into train so that little of
-    the available data is wasted on eval. Each output example carries:
+    Two loading modes, picked by ``dataset_cfg.split``:
+
+      - ``split is None`` (default): expects separate ``train`` and ``test``
+        splits. The first ``test_split_size`` test examples become the held-out
+        eval set; the rest is concatenated into train so little data is wasted.
+      - ``split`` set: a single-split dataset (slicing allowed, e.g.
+        ``"validation[:2000]"``). The first ``test_split_size`` examples become
+        the held-out eval set; the remainder is train.
+
+    Each output example carries:
       - text:     fully chat-templated prompt string ready for tokenization
       - target:   raw ground-truth string from `target_field`
       - messages: the messages list, used to append assistant + self-correction
     """
-    dataset = load_dataset(dataset_cfg.name, name=dataset_cfg.config_name, split="train")
-    test_dataset = load_dataset(dataset_cfg.name, name=dataset_cfg.config_name, split="test")
-    if dataset_cfg.test_split_size > len(test_dataset):
-        raise ValueError(
-            f"test_split_size={dataset_cfg.test_split_size} exceeds "
-            f"test set size {len(test_dataset)}"
+    load_kw = {"name": dataset_cfg.config_name, "revision": dataset_cfg.revision}
+    if dataset_cfg.split is not None:
+        full = load_dataset(dataset_cfg.name, split=dataset_cfg.split, **load_kw)
+        if dataset_cfg.test_split_size >= len(full):
+            raise ValueError(
+                f"test_split_size={dataset_cfg.test_split_size} must be < "
+                f"single-split dataset size {len(full)}"
+            )
+        train_dataset = full.select(range(dataset_cfg.test_split_size, len(full)))
+        test_dataset = full.select(range(dataset_cfg.test_split_size))
+    else:
+        dataset = load_dataset(dataset_cfg.name, split="train", **load_kw)
+        test_dataset = load_dataset(dataset_cfg.name, split="test", **load_kw)
+        if dataset_cfg.test_split_size > len(test_dataset):
+            raise ValueError(
+                f"test_split_size={dataset_cfg.test_split_size} exceeds "
+                f"test set size {len(test_dataset)}"
+            )
+        held_out = test_dataset.select(range(dataset_cfg.test_split_size))
+        extra_train = test_dataset.select(
+            range(dataset_cfg.test_split_size, len(test_dataset))
         )
-
-    held_out = test_dataset.select(range(dataset_cfg.test_split_size))
-    extra_train = test_dataset.select(
-        range(dataset_cfg.test_split_size, len(test_dataset))
-    )
-    train_dataset = concatenate_datasets([dataset, extra_train])
-    test_dataset = held_out
+        train_dataset = concatenate_datasets([dataset, extra_train])
+        test_dataset = held_out
 
     def build(examples: dict[str, list]) -> dict[str, list]:
         messages = [

--- a/train.py
+++ b/train.py
@@ -269,10 +269,15 @@ def load_and_prepare_data(
                 f"test set size {len(test_dataset)}"
             )
         held_out = test_dataset.select(range(dataset_cfg.test_split_size))
-        extra_train = test_dataset.select(
-            range(dataset_cfg.test_split_size, len(test_dataset))
-        )
-        train_dataset = concatenate_datasets([dataset, extra_train])
+        # Spill any unused test examples back into train. When test_split_size
+        # consumes the whole test split there's nothing to spill — and an empty
+        # contiguous .select() trips a bounds check in `datasets`, so skip it.
+        if dataset_cfg.test_split_size < len(test_dataset):
+            extra_train = test_dataset.select(
+                range(dataset_cfg.test_split_size, len(test_dataset))
+            )
+            dataset = concatenate_datasets([dataset, extra_train])
+        train_dataset = dataset
         test_dataset = held_out
 
     def build(examples: dict[str, list]) -> dict[str, list]:


### PR DESCRIPTION
## Why

gsm8k's ~840-token reasoning traces make a full two-stage run take **days** on Spark. This adds a toy task that finishes in **a few hours** — for validating the training loop / new features (checkpoints, resume, length_norm, strict reward) before spending Spark wallclock on a real run.

## The task — picked empirically

`EleutherAI/arithmetic`, **`5da` subset (5-digit addition)**, e.g. `65360 + 16204 = 81564`.

I probed Qwen3-0.6B across every subset *at the shipped config* to find the SCoRe Goldilocks zone (attempt-1 accuracy meaningfully below 100% so self-correction has room, but not near-zero):

| subset | attempt-1 acc | note |
|---|---|---|
| 1-2 digit add/sub | ~88-92% | too easy |
| 3-digit add | ~92% | too easy |
| 4-digit add/sub | ~74% | borderline |
| **5-digit add** | **~68%** | **picked — clean Goldilocks, 88% format compliance, 12% truncation** |
| 5-digit sub | ~48% | tempting acc, but 42% truncation -> poisoned signal |

**Methodology note**: early probes at a 256-token budget showed misleadingly *low* accuracy ("3da = 60%") — that was a **truncation artifact**, not difficulty. Qwen3-0.6B's thinking mode rambles ~400+ tokens for *any* arithmetic; at 256 tokens ~half the rollouts were cut off before producing an answer. The table above is measured at the real config (768 tokens, tight prompt).

## Config highlights

- `max_new_tokens: 768` — needed; 256 truncated half of all rollouts.
- `max_seq_length: 2048`, `max_prompt_length_attempt2: 1024` — fit the larger gen budget.
- **Tightened system prompt** — demands the exact `<think>/<answer>` format + brevity. This alone took pre-training format compliance from ~4% -> ~88% in the probe.
- 1800 train / 200 eval at batch 32 -> ~56 steps/stage (vs gsm8k's 269); generation averages ~410 tokens (vs ~840). A full two-stage run is a few hours.

## 2 generic `DatasetConfig` additions (both default `None` -> zero change for gsm8k/math)

`EleutherAI/arithmetic` ships a legacy dataset script (modern `datasets` rejects it) and only a `validation` split:

- **`revision`** — pin to a HF dataset revision. Here `refs/convert/parquet`, the auto-generated parquet export.
- **`split`** — load just this one split spec (slicing allowed, e.g. `validation[16000:18000]` — the parquet export concatenates all 10 subsets in order, rows 16000-17999 are `arithmetic_5da`) and partition into train + held-out eval.

## No new extractor needed

Shipped `gsm8k_hash` handles it — pulls the number from `<answer>N</answer>` predictions and from the bare numeric target.

## Verification

- Data path standalone (no GPU): config parses, single-split mode loads + partitions (2000 -> 1800/200), confirmed the slice is `arithmetic_5da`, `gsm8k_hash` round-trips.
- Difficulty + format compliance measured on Spark in the `unsloth-dgx-spark` container — 4 probe runs across subsets and token budgets to land on `5da`.

## Usage

```bash
python train.py --config configs/arithmetic.yaml --smoke 8   # smoke
python train.py --config configs/arithmetic.yaml             # full (~a few hours)
```